### PR TITLE
Add support for hashicorp vault dynamic database secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ We use the following general structure to specify sync mapping for all providers
 # you can use either `env_sync` or `env` or both
 env_sync:
   path: ... # path to mapping
+  remap:
+    PROVIDER_VAR1: VAR3 # Maps PROVIDER_VAR1 to local env var VAR3
 env:
   VAR1:
     path: ... # path to value or mapping
@@ -190,6 +192,19 @@ env:
     path: ...
 ```
 
+### Remapping Provider Variables
+
+Providers which support syncing a list of keys and values can be remapped to different environment variable keys. Typically, when teller syncs paths from `env_sync`, the key returned from the provider is directly mapped to the environment variable key. In some cases it might be necessary to have the provider key mapped to a different variable without changing the provider settings. This can be useful when using `env_sync` for [Hashicorp Vault Dynamic Database credentials](https://www.vaultproject.io/docs/secrets/databases):
+
+```yaml
+env_sync:
+  path: database/roles/my-role
+  remap:
+    username: PGUSER
+    password: PGPASSWORD
+```
+
+After remapping, the local environment variable `PGUSER` will contain the provider value for `username` and `PGPASSWORD` will contain the provider value for `password`.
 
 ## Hashicorp Vault
 

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -1,11 +1,12 @@
 package core
 
 type KeyPath struct {
-	Env      string `yaml:"env,omitempty"`
-	Path     string `yaml:"path"`
-	Field    string `yaml:"field,omitempty"`
-	Decrypt  bool   `yaml:"decrypt,omitempty"`
-	Optional bool   `yaml:"optional,omitempty"`
+	Env      string            `yaml:"env,omitempty"`
+	Path     string            `yaml:"path"`
+	Field    string            `yaml:"field,omitempty"`
+	Remap    map[string]string `yaml:"remap,omitempty"`
+	Decrypt  bool              `yaml:"decrypt,omitempty"`
+	Optional bool              `yaml:"optional,omitempty"`
 }
 type WizardAnswers struct {
 	Project      string

--- a/pkg/providers/hashicorp_vault.go
+++ b/pkg/providers/hashicorp_vault.go
@@ -41,7 +41,13 @@ func (h *HashicorpVault) GetMapping(p core.KeyPath) ([]core.EnvEntry, error) {
 		return nil, err
 	}
 
-	k := secret.Data["data"].(map[string]interface{})
+	// vault returns a secret kv struct as either data{} or data.data{} depending on engine
+	var k map[string]interface{}
+	if val, ok := secret.Data["data"]; ok {
+		k = val.(map[string]interface{})
+	} else {
+		k = secret.Data
+	}
 
 	entries := []core.EnvEntry{}
 	for k, v := range k {
@@ -57,7 +63,14 @@ func (h *HashicorpVault) Get(p core.KeyPath) (*core.EnvEntry, error) {
 		return nil, err
 	}
 
-	data := secret.Data["data"].(map[string]interface{})
+	// vault returns a secret kv struct as either data{} or data.data{} depending on engine
+	var data map[string]interface{}
+	if val, ok := secret.Data["data"]; ok {
+		data = val.(map[string]interface{})
+	} else {
+		data = secret.Data
+	}
+
 	k := data[p.Env]
 	if p.Field != "" {
 		k = data[p.Field]
@@ -81,7 +94,7 @@ func (h *HashicorpVault) getSecret(kp core.KeyPath) (*api.Secret, error) {
 		return nil, err
 	}
 
-	if secret == nil || secret.Data["data"] == nil {
+	if secret == nil || len(secret.Data) == 0 {
 		return nil, fmt.Errorf("data not found at '%s'", kp.Path)
 	}
 

--- a/pkg/providers/hashicorp_vault_test.go
+++ b/pkg/providers/hashicorp_vault_test.go
@@ -19,20 +19,40 @@ func TestHashicorpVault(t *testing.T) {
 	client := mock_providers.NewMockHashicorpClient(ctrl)
 	path := "settings/prod/billing-svc"
 	pathmap := "settings/prod/billing-svc/all"
-	out := api.Secret{
-		Data: map[string]interface{}{
-			"data": map[string]interface{}{
-				"MG_KEY":    "shazam",
-				"SMTP_PASS": "mailman",
+
+	tests := map[string]struct {
+		out api.Secret
+	}{
+		"data.data": {
+			out: api.Secret{
+				Data: map[string]interface{}{
+					"data": map[string]interface{}{
+						"MG_KEY":    "shazam",
+						"SMTP_PASS": "mailman",
+					},
+				},
+			},
+		},
+		"data": {
+			out: api.Secret{
+				Data: map[string]interface{}{
+					"MG_KEY":    "shazam",
+					"SMTP_PASS": "mailman",
+				},
 			},
 		},
 	}
-	client.EXPECT().Read(gomock.Eq(path)).Return(&out, nil).AnyTimes()
-	client.EXPECT().Read(gomock.Eq(pathmap)).Return(&out, nil).AnyTimes()
-	s := HashicorpVault{
-		client: client,
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client.EXPECT().Read(gomock.Eq(path)).Return(&tc.out, nil).AnyTimes()
+			client.EXPECT().Read(gomock.Eq(pathmap)).Return(&tc.out, nil).AnyTimes()
+			s := HashicorpVault{
+				client: client,
+			}
+			AssertProvider(t, &s, true)
+		})
 	}
-	AssertProvider(t, &s, true)
 }
 
 func TestHashicorpVaultFailures(t *testing.T) {

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -164,6 +164,14 @@ func (tl *Teller) Collect() error {
 			if err != nil {
 				return err
 			}
+
+			// optionally remap environment variables synced from the provider
+			for k, v := range es {
+				if val, ok := conf.EnvMapping.Remap[v.Key]; ok {
+					es[k].Key = val
+				}
+			}
+
 			entries = append(entries, es...)
 		}
 		if conf.Env != nil {


### PR DESCRIPTION
- Add support in `HashicorpVault.GetMapping()` and `HashicorpVault.Get()` to handle provider responses which may have either `data.data{}` or `data{}`. This enables support for the Hashicorp Vault dynamic secrets backend.
- Add the ability to remap keys from providers to different local environment variable keys when using `env_sync`. This allows mapping the hashicorp vault response for dynamic secrets to the correct postgres username and password environment variables. Vault will always return `data{username: '<user>', password: '<pass>'`, however postgres expects `PGUSER` and `PGPASSWORD`. With remapping we can set `PGUSER = username` and `PGPASSWORD = password`.

Resolves #4 