### PR TITLE
Implement AWS Secrets Manager `Put` and `PutMapping` as upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ Your standard `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
 
 * Sync - `yes`
 * Mapping - `yes`
-* Modes - `read`, [write: accepting PR](https://github.com/spectralops/teller)
+* Modes - `read+write`
 * Key format 
   * `env_sync` - path based
   * `env` - path based

--- a/pkg/providers/aws_secretsmanager.go
+++ b/pkg/providers/aws_secretsmanager.go
@@ -3,24 +3,23 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-
 	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/spectralops/teller/pkg/core"
+	"github.com/spectralops/teller/pkg/utils"
 )
 
-/*
-build interface for the client,
-replace with this,
-in tests use literal constructor
-rig the mock inside
-*/
 type AWSSecretsManagerClient interface {
 	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+	CreateSecret(ctx context.Context, params *secretsmanager.CreateSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error)
+	PutSecretValue(ctx context.Context, params *secretsmanager.PutSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.PutSecretValueOutput, error)
 }
+
 type AWSSecretsManager struct {
 	client AWSSecretsManagerClient
 }
@@ -41,65 +40,93 @@ func (a *AWSSecretsManager) Name() string {
 }
 
 func (a *AWSSecretsManager) GetMapping(p core.KeyPath) ([]core.EnvEntry, error) {
-	secret, err := a.getSecret(p)
+	kvs, err := a.getSecret(p)
 	if err != nil {
 		return nil, err
 	}
 
-	k := secret
-
-	entries := []core.EnvEntry{}
-	for k, v := range k {
+	var entries []core.EnvEntry
+	for k, v := range kvs {
 		entries = append(entries, p.FoundWithKey(k, v))
 	}
 	sort.Sort(core.EntriesByKey(entries))
 	return entries, nil
 }
 
-func (a *AWSSecretsManager) Put(p core.KeyPath, val string) error {
-	return fmt.Errorf("%v does not implement write yet", a.Name())
+func (a *AWSSecretsManager) Put(kp core.KeyPath, val string) error {
+	k := kp.EffectiveKey()
+	return a.PutMapping(kp, map[string]string{k: val})
 }
 
-func (a *AWSSecretsManager) PutMapping(p core.KeyPath, m map[string]string) error {
-	return fmt.Errorf("%v does not implement write yet", a.Name())
+func (a *AWSSecretsManager) PutMapping(kp core.KeyPath, m map[string]string) error {
+	secrets, err := a.getSecret(kp)
+	if err != nil {
+		return err
+	}
+
+	secretAlreadyExist := len(secrets) != 0
+
+	utils.Merge(m, secrets)
+	secretBytes, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	secretString := string(secretBytes)
+	ctx := context.Background()
+	if secretAlreadyExist {
+		// secret already exist - put new value
+		_, err = a.client.PutSecretValue(ctx, &secretsmanager.PutSecretValueInput{SecretId: &kp.Path, SecretString: &secretString})
+		return err
+	}
+
+	// create secret
+	_, err = a.client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{Name: &kp.Path, SecretString: &secretString})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (a *AWSSecretsManager) Get(p core.KeyPath) (*core.EnvEntry, error) {
-	secret, err := a.getSecret(p)
+func (a *AWSSecretsManager) Get(kp core.KeyPath) (*core.EnvEntry, error) {
+	kvs, err := a.getSecret(kp)
 	if err != nil {
 		return nil, err
 	}
 
-	data := secret
-	k, ok := data[p.Env]
-	if p.Field != "" {
-		k, ok = data[p.Field]
-	}
-
+	k := kp.EffectiveKey()
+	val, ok := kvs[k]
 	if !ok {
-		ent := p.Missing()
+		ent := kp.Missing()
 		return &ent, nil
 	}
 
-	ent := p.Found(k)
+	ent := kp.Found(val)
 	return &ent, nil
 }
 
 func (a *AWSSecretsManager) getSecret(kp core.KeyPath) (map[string]string, error) {
-	res, err := a.client.GetSecretValue(context.TODO(), &secretsmanager.GetSecretValueInput{SecretId: &kp.Path})
+	res, err := a.client.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{SecretId: &kp.Path})
 	if err != nil {
-		return nil, err
+		var resNotFound *smtypes.ResourceNotFoundException
+		if !errors.As(err, &resNotFound) {
+			return nil, err
+		}
+
+		// doesn't exist - do not treat as an error
+		return nil, nil
 	}
 
 	if res == nil || res.SecretString == nil {
-		return nil, fmt.Errorf("data not found at '%s'", kp.Path)
+		return nil, fmt.Errorf("data not found at %q", kp.Path)
 	}
-	m := map[string]string{}
-	err = json.Unmarshal([]byte(*res.SecretString), &m)
 
+	var secret map[string]string
+	err = json.Unmarshal([]byte(*res.SecretString), &secret)
 	if err != nil {
 		return nil, err
 	}
 
-	return m, nil
+	return secret, nil
 }

--- a/pkg/providers/dotenv.go
+++ b/pkg/providers/dotenv.go
@@ -93,7 +93,7 @@ func (a *Dotenv) GetMapping(p core.KeyPath) ([]core.EnvEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	entries := []core.EnvEntry{}
+	var entries []core.EnvEntry
 	for k, v := range kvs {
 		entries = append(entries, p.FoundWithKey(k, v))
 	}
@@ -109,7 +109,6 @@ func (a *Dotenv) Get(p core.KeyPath) (*core.EnvEntry, error) {
 
 	k := p.EffectiveKey()
 	val, ok := kvs[k]
-
 	if !ok {
 		ent := p.Missing()
 		return &ent, nil

--- a/pkg/providers/mock_providers/aws_secretsmanager_mock.go
+++ b/pkg/providers/mock_providers/aws_secretsmanager_mock.go
@@ -35,6 +35,26 @@ func (m *MockAWSSecretsManagerClient) EXPECT() *MockAWSSecretsManagerClientMockR
 	return m.recorder
 }
 
+// CreateSecret mocks base method.
+func (m *MockAWSSecretsManagerClient) CreateSecret(ctx context.Context, params *secretsmanager.CreateSecretInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateSecret", varargs...)
+	ret0, _ := ret[0].(*secretsmanager.CreateSecretOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSecret indicates an expected call of CreateSecret.
+func (mr *MockAWSSecretsManagerClientMockRecorder) CreateSecret(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockAWSSecretsManagerClient)(nil).CreateSecret), varargs...)
+}
+
 // GetSecretValue mocks base method.
 func (m *MockAWSSecretsManagerClient) GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
 	m.ctrl.T.Helper()
@@ -53,4 +73,24 @@ func (mr *MockAWSSecretsManagerClientMockRecorder) GetSecretValue(ctx, params in
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, params}, optFns...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockAWSSecretsManagerClient)(nil).GetSecretValue), varargs...)
+}
+
+// PutSecretValue mocks base method.
+func (m *MockAWSSecretsManagerClient) PutSecretValue(ctx context.Context, params *secretsmanager.PutSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.PutSecretValueOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PutSecretValue", varargs...)
+	ret0, _ := ret[0].(*secretsmanager.PutSecretValueOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutSecretValue indicates an expected call of PutSecretValue.
+func (mr *MockAWSSecretsManagerClientMockRecorder) PutSecretValue(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValue", reflect.TypeOf((*MockAWSSecretsManagerClient)(nil).PutSecretValue), varargs...)
 }

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -8,6 +8,10 @@ func LastSegment(s string) string {
 }
 
 func Merge(from, into map[string]string) {
+	if into == nil {
+		into = make(map[string]string)
+	}
+
 	for k, v := range from {
 		into[k] = v
 	}


### PR DESCRIPTION
Hi,

As we need badly the `Put` and `PutMapping` functionality for AWS Secrets Manager, this pull request brings such functionality. Hope you'll like it! 🙂 

**NOTE:** I saw an open pull request #47 from @JacobJohansen, which, among other things, also implements the `Put` for AWS Secrets Manager.
However, this PR doesn't bring upsert behavior to the `Put` and `PutMapping` methods, and as discussed on #54, such behavior is expected. 

Also, I saw some failing tests and inactivity on that pull request, that's why I created another PR.  But, I will be happy to rebase my changes to the Jacob's branch, if #47 is going to be fixed and merged soon 🙂  Regardless the option, Jacob's pull request still introduces something more - `Put` method implementation for AWS SSM, so our PRs don't overlap in 100%.

## Minimal example

```go
package main

import (
	tellerpkg "github.com/spectralops/teller/pkg"
	"github.com/spectralops/teller/pkg/core"
	"log"
)

// AWS Secrets Manager needs AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY envs during go run
func main() {
	providers := tellerpkg.BuiltinProviders{}
	provider, err := providers.GetProvider("aws_secretsmanager")
	if err != nil {
		panic(err)
	}

	key := core.KeyPath{
		Path:  "/prod/sample",
		Field: "data",
	}

	val := `{"key": "false"}`
	err = provider.Put(key, val)
	if err != nil {
		panic(err)
	}

	// Get
	entry, err := provider.Get(key)
	if err != nil {
		panic(err)
	}

	log.Printf("%+v\n", entry)
}

```