### PR TITLE
Introduce Teller `delete` command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,38 @@ A few notes:
 * While you can push to multiple providers, please make sure the _path semantics_ are the same
 
 
+## :x: Delete and multi-delete from providers
+
+Teller providers support _deleting_ values _from_ providers.
+
+This feature revolves around definitions in your `teller.yml` file:
+
+```bash
+$ teller delete FOO_BAR --providers dotenv -c .teller.yml
+```
+
+A few notes:
+
+* You can specify multiple keys to delete, for example:
+
+  ```bash
+  $ teller delete FOO BAR BAZ --providers dotenv
+  ```
+* The flag `--providers` lets you push to one or more providers at once
+* All keys must be a mapped key in your configuration for each provider you want to delete from
+
+
+Sometimes you don't have a mapped key in your configuration file and want to perform an ad-hoc delete. You can do that with the `--path` flag:
+
+```bash
+$ teller delete FOO BAR --path ~/my-env-file.env --providers dotenv
+```
+
+You can also delete all keys at once for a given path, without specifying them one by one:
+
+```bash
+$ teller delete --all-keys --path ~/my-env-file.env --providers dotenv
+```
 
 ## :white_check_mark: Prompts and options
 
@@ -607,7 +639,7 @@ Your standard `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
 
 * Sync - `yes`
 * Mapping - `yes`
-* Modes - `read+write`
+* Modes - `read+write+delete`
 * Key format 
   * `env_sync` - path based
   * `env` - path based
@@ -687,7 +719,7 @@ No need. You'll be pointing to a one or more `.env` files on your disk.
 
 * Sync - `yes`
 * Mapping - `yes`
-* Modes - `read+write`
+* Modes - `read+write+delete`
 * Key format 
   * `env` - env key like
 

--- a/main.go
+++ b/main.go
@@ -74,6 +74,12 @@ var CLI struct {
 		Source string `name:"source" help:"A source to check drift against"`
 		Target string `name:"target" help:"A target to check against source"`
 	} `cmd help:"Check same-key (mirror) value drift between source and target"`
+
+	Delete struct {
+		Keys      []string `arg name:"keys" help:"A list of keys, where key is from your tellerfile mapping"`
+		Providers []string `name:"providers" help:"A list of providers to delete the key from"`
+		Path      string   `optional name:"path" help:"Take literal path and not from config"`
+	} `cmd help:"Delete a secret"`
 }
 
 var (
@@ -152,6 +158,13 @@ func main() {
 		}
 		if len(drifts) > 0 {
 			teller.Porcelain.PrintDrift(drifts)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	case "delete":
+		err := teller.Delete(CLI.Delete.Keys, CLI.Delete.Providers, CLI.Delete.Path)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
 		os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -76,9 +76,10 @@ var CLI struct {
 	} `cmd help:"Check same-key (mirror) value drift between source and target"`
 
 	Delete struct {
-		Keys      []string `arg name:"keys" help:"A list of keys, where key is from your tellerfile mapping"`
+		Keys      []string `arg optional name:"keys" help:"A list of keys, where key is from your tellerfile mapping"`
 		Providers []string `name:"providers" help:"A list of providers to delete the key from"`
 		Path      string   `optional name:"path" help:"Take literal path and not from config"`
+		AllKeys   bool     `optional name:"all-keys" help:"Deletes all keys for a given path. Applicable only when used together with the 'path' flag"`
 	} `cmd help:"Delete a secret"`
 }
 
@@ -162,7 +163,14 @@ func main() {
 		}
 		os.Exit(0)
 	case "delete":
-		err := teller.Delete(CLI.Delete.Keys, CLI.Delete.Providers, CLI.Delete.Path)
+		err := teller.Delete(CLI.Delete.Keys, CLI.Delete.Providers, CLI.Delete.Path, CLI.Delete.AllKeys)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	case "delete <keys>":
+		err := teller.Delete(CLI.Delete.Keys, CLI.Delete.Providers, CLI.Delete.Path, CLI.Delete.AllKeys)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)

--- a/pkg/porcelain.go
+++ b/pkg/porcelain.go
@@ -188,3 +188,16 @@ func (p *Porcelain) NoPutKVP(k, pname string) {
 	yellow := color.New(color.FgYellow).SprintFunc()
 	fmt.Fprintf(p.Out, "Put %v in %v: no such key '%v' in mapping\n", yellow(k), green(pname), yellow(k))
 }
+
+func (p *Porcelain) DidDeleteKP(kp core.KeyPath, pname string) {
+	green := color.New(color.FgGreen).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
+	gray := color.New(color.FgHiBlack).SprintFunc()
+	fmt.Fprintf(p.Out, "Delete %v (%v) in %v: OK.\n", yellow(kp.Env), gray(kp.Path), green(pname))
+}
+
+func (p *Porcelain) NoDeleteKP(k, pname string) {
+	green := color.New(color.FgGreen).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
+	fmt.Fprintf(p.Out, "Delete %v in %v: no such key '%v' in mapping\n", yellow(k), green(pname), yellow(k))
+}

--- a/pkg/porcelain.go
+++ b/pkg/porcelain.go
@@ -201,3 +201,9 @@ func (p *Porcelain) NoDeleteKP(k, pname string) {
 	yellow := color.New(color.FgYellow).SprintFunc()
 	fmt.Fprintf(p.Out, "Delete %v in %v: no such key '%v' in mapping\n", yellow(k), green(pname), yellow(k))
 }
+
+func (p *Porcelain) DidDeleteP(path, pname string) {
+	green := color.New(color.FgGreen).SprintFunc()
+	gray := color.New(color.FgHiBlack).SprintFunc()
+	fmt.Fprintf(p.Out, "Delete mapping in path %v in %v: OK.\n", gray(path), green(pname))
+}


### PR DESCRIPTION
This pull request supports the following `delete` scenarios:
- Delete keys based on mapping in config
- Delete keys by secret path
- Delete all keys based on path

I also updated the documentation and wrote basic tests for different delete cases.

~**NOTE: Do not merge it yet:** This PR depends on #60. Once the #60 is reviewed, approved and merged, I will rebase this one.~ PR #60 has been successfully merged, and this PR has been rebased to the latest `master`.

Resolves #57 

## Testing scenario

```bash
cat > ./.teller.yml << ENDOFFILE
project: sample
opts: {}
prefix:
  stage: development

providers:
  # you can mix and match many files
  dotenv:
    env_sync:
      path: ~/my-dot-env2.env
    env:
      FOO:
        path: ~/my-dot-env.env
      BAR:
        path: ~/my-dot-env.env
      BAZ:
        path: ~/my-dot-env.env
ENDOFFILE

# delete - based on config
go run ./main.go put FOO=foo --providers=dotenv
go run ./main.go put BAR=bar BAZ=baz --providers=dotenv
go run ./main.go show
go run ./main.go delete BAR --providers dotenv
go run ./main.go show
go run ./main.go delete FOO BAZ --providers dotenv
go run ./main.go show
cat ~/my-dot-env.env # file has been properly cleaned up

# delete - by path
go run ./main.go put FOO=foo BAR=bar BAZ=baz --providers=dotenv
go run ./main.go delete FOO BAR --path=~/my-dot-env.env --providers=dotenv
go run ./main.go show
go run ./main.go delete BAZ --path=~/my-dot-env.env --providers=dotenv
go run ./main.go show
cat ~/my-dot-env.env # file has been properly cleaned up

# delete - by path - all keys
go run ./main.go put FOO=foo BAR=bar BAZ=baz --providers=dotenv
go run ./main.go show
go run ./main.go delete --all-keys --path=~/my-dot-env.env --providers=dotenv
go run ./main.go show
cat ~/my-dot-env.env # file has been properly cleaned up
```
