### PR TITLE
adding github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug Report
+about: Report a bug encountered 
+labels: bug
+---
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!-- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!-- Not obligatory, but suggest a fix/reason for the bug -->
+
+## Steps to Reproduce
+<!--- Steps to reproduce this bug. Include the command line with flags-->
+1.
+2.
+3.
+4.
+
+## Context
+<!-- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Specifications
+  - Version: `$ teller version`
+  - Platform:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: "Feature Request"
+about: Suggest a new feature
+labels: "enhancement"
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I have an issue when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->

--- a/.github/ISSUE_TEMPLATE/new_provider.md
+++ b/.github/ISSUE_TEMPLATE/new_provider.md
@@ -1,0 +1,14 @@
+---
+name: "\U0001F680 New Provider"
+about: Adding new provider
+labels: "new-provider"
+---
+
+## New Provider Request
+
+## Details
+- Name: 
+- URL:
+- Modes: (read/write/read+write)
+- GitHub projects: 
+- API Documentation: 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Related Issues
+<!-- - #[ISSUE-ID]-->
+
+## Description
+<!-- Describe your changes in detail -->
+
+## Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!-- Please describe in detail how you tested your changes. -->
+<!-- Include details of your testing environment, and the tests you ran to -->
+<!-- see how your change affects other areas of the code, etc. -->
+
+# Checklist
+- [ ] Tests
+- [ ] Documentation
+- [ ] Linting


### PR DESCRIPTION
Add GitHub templates:
1. `Bug Report` -> template for each new bug report. Ticket automatic labels as `bug` 
2. `Feature Request` -> template when want to request a new feature. Ticket automatic labels as `enhancement`
3. `Adding new provider` -> template when users requested a new provider. Ticket automatic labels as `new-provider`
4. `Pull request`-> template for new pull request

Let me know if you have more template suggestions 
