### PR TITLE
add goreleaser to ci step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: Release
+on:
+  push:
+    tags:
+    - 'v*.*.*'
+    - 'v*.*.*-rc*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: v1.7.0
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ todo.txt
 .teller.writecase.yml
 coverage.out
 fixtures/sync/target.env
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,9 @@ builds:
       - windows
       - darwin
 
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
## Description
Adding CD to our workflows for releasing new Teller version by git tagging command:
```sh
git tag v... && git push origin v...
```

I have adde `ldflags` flag to `.goreleaser.yml` for inject the the version details.

#### before releasing:
we need to add `GORELEASER_GITHUB_TOKEN` to settings

## Motivation and Context
Easy way to release new Teller versions

## How Has This Been Tested?
This command was run on my local computer
```sh
goreleaser release --snapshot --rm-dist
```

# Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Linting