### PR TITLE
remove HOMEBREW_TAP_GITHUB_TOKEN and take the GORELEASER_GITHUB_TOKEN…

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,8 +25,6 @@ brews:
     tap:
       owner: spectralops
       name: homebrew-tap
-      # Optionally a token can be provided, if it differs from the token provided to GoReleaser
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     description: A secret manager for developers - never leave your terminal for secrets
     homepage:  https://github.com/spectralops/teller
     license: "Apache 2.0"


### PR DESCRIPTION
fix release ci when goreleaser update the release paths in homebrew-tap repository