### PR TITLE
fix: use aliases key instead of short for version cmd

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var CLI struct {
 	} `cmd help:"Run a command"`
 
 	Version struct {
-	} `cmd short:"v" help:"Teller version"`
+	} `cmd aliases:"v" help:"Teller version"`
 
 	New struct {
 	} `cmd help:"Create a new teller configuration file"`


### PR DESCRIPTION
## Description
When using `teller v` the version should be printed however i got this instead
```
teller: error: unexpected argument v, did you mean one of "version", "sh", "env"?
```
And by checking the code I found that `aliases` needs to be used instead of `short` (as teller doesn't have `-v` anyway)

The `help` message will be changed into the mentioned below, which indicates that `version` has a short-hand called `v`
```
  version (v)
    Teller version
```
# Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Linting