### PR TITLE
Group show command output by provider name

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,7 +258,7 @@ func main() {
 		}
 		fmt.Print(out)
 
-	case "show":		
+	case "show":
 		teller.PrintEnvKeys()
 
 	case "scan":

--- a/main.go
+++ b/main.go
@@ -259,6 +259,7 @@ func main() {
 		fmt.Print(out)
 
 	case "show":
+		teller.SortByProviderName()
 		teller.PrintEnvKeys()
 
 	case "scan":

--- a/main.go
+++ b/main.go
@@ -258,8 +258,7 @@ func main() {
 		}
 		fmt.Print(out)
 
-	case "show":
-		teller.SortByProviderName()
+	case "show":		
 		teller.PrintEnvKeys()
 
 	case "scan":

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -99,8 +99,8 @@ func (a DriftedEntriesBySource) Less(i, j int) bool { return a[i].Source.Source 
 
 type EntriesByProvider []EnvEntry
 
-func (a EntriesByProvider) Len() int           { return len(a) }
-func (a EntriesByProvider) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a EntriesByProvider) Len() int      { return len(a) }
+func (a EntriesByProvider) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a EntriesByProvider) Less(i, j int) bool {
 	firstProviderName := strings.ToLower(a[i].ProviderName)
 	secondProviderName := strings.ToLower(a[j].ProviderName)

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -1,5 +1,7 @@
 package core
 
+import "strings"
+
 type Severity string
 
 const (
@@ -99,7 +101,14 @@ type EntriesByProvider []EnvEntry
 
 func (a EntriesByProvider) Len() int           { return len(a) }
 func (a EntriesByProvider) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a EntriesByProvider) Less(i, j int) bool { return a[i].ProviderName < a[j].ProviderName }
+func (a EntriesByProvider) Less(i, j int) bool {
+	firstProviderName := strings.ToLower(a[i].ProviderName)
+	secondProviderName := strings.ToLower(a[j].ProviderName)
+	if firstProviderName != secondProviderName {
+		return firstProviderName < secondProviderName
+	}
+	return a[i].Key < a[j].Key
+}
 
 type EntriesByKey []EnvEntry
 

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -95,6 +95,12 @@ func (a DriftedEntriesBySource) Len() int           { return len(a) }
 func (a DriftedEntriesBySource) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a DriftedEntriesBySource) Less(i, j int) bool { return a[i].Source.Source < a[j].Source.Source }
 
+type EntriesByProvider []EnvEntry
+
+func (a EntriesByProvider) Len() int           { return len(a) }
+func (a EntriesByProvider) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a EntriesByProvider) Less(i, j int) bool { return a[i].ProviderName < a[j].ProviderName }
+
 type EntriesByKey []EnvEntry
 
 func (a EntriesByKey) Len() int           { return len(a) }

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -86,7 +86,7 @@ func (tl *Teller) execCmd(cmd string, cmdArgs []string, withRedaction bool) erro
 }
 
 func (tl *Teller) PrintEnvKeys() {
-	tl.SortByProviderName()
+	tl.sortByProviderName()
 	tl.Porcelain.PrintContext(tl.Config.Project, tl.Config.LoadedFrom)
 	tl.Porcelain.VSpace(1)
 	tl.Porcelain.PrintEntries(tl.Entries)
@@ -483,7 +483,7 @@ func (tl *Teller) Collect() error {
 	return nil
 }
 
-func (tl *Teller) SortByProviderName() {
+func (tl *Teller) sortByProviderName() {
 	sort.Sort(core.EntriesByProvider(tl.Entries))
 }
 

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -86,6 +86,7 @@ func (tl *Teller) execCmd(cmd string, cmdArgs []string, withRedaction bool) erro
 }
 
 func (tl *Teller) PrintEnvKeys() {
+	tl.SortByProviderName()
 	tl.Porcelain.PrintContext(tl.Config.Project, tl.Config.LoadedFrom)
 	tl.Porcelain.VSpace(1)
 	tl.Porcelain.PrintEntries(tl.Entries)

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -482,6 +482,10 @@ func (tl *Teller) Collect() error {
 	return nil
 }
 
+func (tl *Teller) SortByProviderName() {
+	sort.Sort(core.EntriesByProvider(tl.Entries))
+}
+
 func (tl *Teller) Drift(providerNames []string) []core.DriftedEntry {
 	sources := map[string]core.EnvEntry{}
 	targets := map[string][]core.EnvEntry{}

--- a/pkg/teller_test.go
+++ b/pkg/teller_test.go
@@ -286,7 +286,7 @@ func TestTellerPorcelainNonInteractive(t *testing.T) {
 
 func TestTellerEntriesOutputSort(t *testing.T) {
 	var b bytes.Buffer
-	
+
 	entries := []core.EnvEntry{}
 
 	tl := Teller{

--- a/pkg/teller_test.go
+++ b/pkg/teller_test.go
@@ -284,6 +284,48 @@ func TestTellerPorcelainNonInteractive(t *testing.T) {
 
 }
 
+func TestTellerEntriesOutputSort(t *testing.T) {
+	var b bytes.Buffer
+	
+	entries := []core.EnvEntry{}
+
+	tl := Teller{
+		Logger:  getLogger(),
+		Entries: entries,
+		Porcelain: &Porcelain{
+			Out: &b,
+		},
+		Config: &TellerFile{
+			Project:    "test-project",
+			LoadedFrom: "nowhere",
+		},
+	}
+
+	tl.Entries = append(tl.Entries, core.EnvEntry{
+		IsFound: true,
+		Key:     "c", Value: "c", ProviderName: "test-provider", ResolvedPath: "path/kv",
+	})
+	tl.Entries = append(tl.Entries, core.EnvEntry{
+		IsFound: true,
+		Key:     "a", Value: "a", ProviderName: "test-provider", ResolvedPath: "path/kv",
+	})
+	tl.Entries = append(tl.Entries, core.EnvEntry{
+		IsFound: true,
+		Key:     "b", Value: "b", ProviderName: "test-provider", ResolvedPath: "path/kv",
+	})
+	tl.Entries = append(tl.Entries, core.EnvEntry{
+		IsFound: true,
+		Key:     "k", Value: "v", ProviderName: "alpha", ResolvedPath: "path/kv",
+	})
+	tl.Entries = append(tl.Entries, core.EnvEntry{
+		IsFound: true,
+		Key:     "k", Value: "v", ProviderName: "BETA", ResolvedPath: "path/kv",
+	})
+
+	tl.PrintEnvKeys()
+	assert.Equal(t, b.String(), "-*- teller: loaded variables for test-project using nowhere -*-\n\n[alpha path/kv] k = v*****\n[BETA path/kv] k = v*****\n[test-provider path/kv] a = a*****\n[test-provider path/kv] b = b*****\n[test-provider path/kv] c = c*****\n")
+}
+
 func TestTellerDrift(t *testing.T) {
 	tl := Teller{
 		Logger: getLogger(),


### PR DESCRIPTION
## Related Issues
No specific issue

## Description
The changes contain adding Teller the ability to sort its entries by ProviderName (in-case-sensitive) and use this ability only in the `show` command.
The reason I have added it only for the show command is that the other output formats do not print the provider at all, but a mix of all the entries from all the providers, sorted by the entry key.
The show command is the only output command which prints the provider as well.

## Motivation and Context
The show command output the entries with the provider name as the leading detail for each entry.
Since the leading detail is the provider name, and the output should be sorted as in the other output format, I think it is better to sort by provider name.
All the entries within every provider would be sorted by key - ascending.

## How Has This Been Tested?
Tested manually, with 4 providers, with a mix of provider names starting with small/capital letters.
Open to suggestions for a programmatic way of testing it.

![image](https://user-images.githubusercontent.com/44297242/163890463-0ceb651f-2eaf-47c8-9406-1c4c9511712f.png)
![image](https://user-images.githubusercontent.com/44297242/163890551-66119519-4009-431b-b69a-179ec359ce0d.png)


# Checklist
- [ ] Tests
- [ ] Documentation
- [x] Linting