### PR TITLE
add filesystem provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,38 @@ providers:
 
 ```
 
+## FileSystem
+
+Allows to work against filesystem structure. for example:
+```
+.
+└── /folder
+    ├── settings/
+    │   ├── billing-svc
+    │   └── all/
+    │       ├── foo
+    └── bar
+```
+
+### Features
+
+* Sync - `yes`
+* Mapping - `yes`
+* Modes - `read+write`
+
+### Example Config
+
+```yaml
+
+providers:
+  filesystem:
+    env_sync:
+      path:  /folder/settings
+    env:
+      ETC_DSN:
+        path: /folder/bar
+```
+
 # Semantics
 
 ## Addressing

--- a/pkg/providers.go
+++ b/pkg/providers.go
@@ -37,10 +37,11 @@ func (p *BuiltinProviders) ProviderHumanToMachine() map[string]string {
 		"LastPass":                    "lastpass",
 		"GitHub":                      "github",
 		"KeyPass":                     "keypass",
+		"FileSystem":                  "filesystem",
 	}
 }
 
-func (p *BuiltinProviders) GetProvider(name string) (core.Provider, error) {
+func (p *BuiltinProviders) GetProvider(name string) (core.Provider, error) { //nolint
 	logger := logging.GetRoot().WithField("provider_name", name)
 	switch name {
 	case "hashicorp_vault":
@@ -81,6 +82,8 @@ func (p *BuiltinProviders) GetProvider(name string) (core.Provider, error) {
 		return providers.NewGitHub(logger)
 	case "keypass":
 		return providers.NewKeyPass(logger)
+	case "filesystem":
+		return providers.NewFileSystem(logger)
 	default:
 		return nil, fmt.Errorf("provider '%s' does not exist", name)
 	}

--- a/pkg/providers/filesystem.go
+++ b/pkg/providers/filesystem.go
@@ -1,0 +1,134 @@
+package providers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/karrick/godirwalk"
+	"github.com/spectralops/teller/pkg/core"
+
+	"github.com/spectralops/teller/pkg/logging"
+)
+
+type FileSystem struct {
+	logger        logging.Logger
+	rootDirectory string
+}
+
+// NewFileSystem creates new provider instance
+func NewFileSystem(logger logging.Logger) (core.Provider, error) {
+
+	return &FileSystem{
+		logger:        logger,
+		rootDirectory: "",
+	}, nil
+}
+
+// Name return the provider name
+func (f *FileSystem) Name() string {
+	return "FileSystem"
+}
+
+// Put will create a new single entry
+func (f *FileSystem) Put(p core.KeyPath, val string) error {
+	return f.writeFile(f.getFilePath(p.Path), val)
+}
+
+// PutMapping will create a multiple entries
+func (f *FileSystem) PutMapping(p core.KeyPath, m map[string]string) error {
+	for k, v := range m {
+		ap := p.SwitchPath(fmt.Sprintf("%v/%v", f.getFilePath(p.Path), k))
+		err := f.Put(ap, v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetMapping returns a multiple entries
+func (f *FileSystem) GetMapping(p core.KeyPath) ([]core.EnvEntry, error) {
+
+	findings := []core.EnvEntry{}
+	err := godirwalk.Walk(f.getFilePath(p.Path), &godirwalk.Options{
+		Callback: func(osPathname string, de *godirwalk.Dirent) error {
+			if de.IsRegular() {
+				content, err := f.readFile(osPathname)
+				if err != nil {
+					f.logger.WithError(err).WithField("path", p.Path).Debug("file not found in path")
+					return nil
+				}
+				findings = append(findings, p.FoundWithKey(strings.Replace(osPathname, fmt.Sprintf("%s/", p.Path), "", 1), string(content)))
+			}
+			return nil
+		},
+		Unsorted: true,
+	})
+
+	return findings, err
+}
+
+// Get returns a single entry
+func (f *FileSystem) Get(p core.KeyPath) (*core.EnvEntry, error) {
+	content, err := f.readFile(f.getFilePath(p.Path))
+	if err != nil {
+		f.logger.WithError(err).WithField("path", p.Path).Debug("file not found in path")
+		return nil, err
+	}
+	ent := p.Found(string(content))
+	return &ent, nil
+}
+
+// Delete will delete entry
+func (f *FileSystem) Delete(kp core.KeyPath) error {
+	deletePath := f.getFilePath(kp.Path)
+	fileInfo, err := os.Stat(deletePath)
+	if err != nil {
+		return err
+	}
+	// to make the delete safely, we allow deleting a single file only
+	if fileInfo.IsDir() {
+		return errors.New("delete folder is not supported")
+	}
+
+	return os.Remove(deletePath)
+}
+
+// DeleteMapping will delete the given path recessively
+func (f *FileSystem) DeleteMapping(kp core.KeyPath) error {
+	return fmt.Errorf("provider mapping %s does not implement delete yet", f.Name())
+}
+
+func (f *FileSystem) getFilePath(p string) string {
+	if f.rootDirectory == "" {
+		return p
+	}
+	return filepath.Join(f.rootDirectory, p)
+}
+
+func (f *FileSystem) writeFile(to, val string) error {
+	f.logger.WithField("path", to).Info("put entry value")
+	dir, _ := path.Split(to)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		f.logger.WithField("dir", dir).Debug("create folder path")
+		err = os.MkdirAll(dir, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(to, []byte(val), 0600) //nolint
+}
+
+func (f *FileSystem) readFile(filePath string) ([]byte, error) {
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(content, []byte("\n")), nil
+}

--- a/pkg/providers/filesystem.go
+++ b/pkg/providers/filesystem.go
@@ -63,7 +63,7 @@ func (f *FileSystem) GetMapping(p core.KeyPath) ([]core.EnvEntry, error) {
 					f.logger.WithError(err).WithField("path", p.Path).Debug("file not found in path")
 					return nil
 				}
-				findings = append(findings, p.FoundWithKey(strings.Replace(osPathname, fmt.Sprintf("%s/", p.Path), "", 1), string(content)))
+				findings = append(findings, p.FoundWithKey(strings.Replace(path.Clean(osPathname), fmt.Sprintf("%s/", p.Path), "", 1), string(content)))
 			}
 			return nil
 		},
@@ -99,7 +99,7 @@ func (f *FileSystem) Delete(kp core.KeyPath) error {
 	return os.Remove(deletePath)
 }
 
-// DeleteMapping will delete the given path recessively
+// DeleteMapping will delete the given path
 func (f *FileSystem) DeleteMapping(kp core.KeyPath) error {
 	return fmt.Errorf("provider mapping %s does not implement delete yet", f.Name())
 }
@@ -130,5 +130,7 @@ func (f *FileSystem) readFile(filePath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return bytes.TrimSuffix(content, []byte("\n")), nil
+	content = bytes.TrimSuffix(content, []byte("\n"))
+	content = bytes.TrimSuffix(content, []byte("\r\n"))
+	return content, nil
 }

--- a/pkg/providers/filesystem_test.go
+++ b/pkg/providers/filesystem_test.go
@@ -1,0 +1,107 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/spectralops/teller/pkg/core"
+)
+
+func createMockDirectoryStructure(f *FileSystem) error {
+	createFileSystemData := []struct {
+		path     string
+		fileName string
+		value    string
+	}{
+		{"settings/prod", "billing-svc", "shazam"},
+		{"settings/prod/billing/all", "secret-a", "mailman"},
+		{"settings/prod/billing/all", "secret-b", "shazam"},
+		{"settings/prod/billing/all/folder", "secret-c", "shazam-1"},
+	}
+
+	for _, filePath := range createFileSystemData {
+		err := os.MkdirAll(filepath.Join(f.rootDirectory, filePath.path), os.ModePerm)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(filepath.Join(f.rootDirectory, filePath.path, filePath.fileName), []byte(filePath.value), 0644)
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func TestFileSystem(t *testing.T) {
+
+	tempFolder, err := os.MkdirTemp(os.TempDir(), "teller-filesystem")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tempFolder)
+
+	f := &FileSystem{
+		logger:        GetTestLogger(),
+		rootDirectory: tempFolder,
+	}
+
+	err = createMockDirectoryStructure(f)
+	assert.NoError(t, err)
+
+	AssertProvider(t, f, false)
+	ents, err := f.GetMapping(core.KeyPath{Path: "settings/prod/billing/all", Decrypt: true})
+	assert.Nil(t, err)
+	assert.Equal(t, len(ents), 3)
+}
+
+func TestFileSystemSetEntry(t *testing.T) {
+
+	tempFolder, err := os.MkdirTemp(os.TempDir(), "teller-filesystem")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tempFolder)
+
+	f := &FileSystem{
+		logger:        GetTestLogger(),
+		rootDirectory: tempFolder,
+	}
+	err = createMockDirectoryStructure(f)
+	assert.NoError(t, err)
+
+	destFile := "create/newfolder/foo"
+	_, err = f.Get(core.KeyPath{Path: destFile, Decrypt: true})
+	assert.NotEmpty(t, err)
+
+	err = f.Put(core.KeyPath{Path: destFile}, "new-val")
+	assert.Nil(t, err)
+
+	results, err := f.Get(core.KeyPath{Path: destFile, Decrypt: true})
+	assert.Nil(t, err)
+	assert.NotEmpty(t, results)
+
+}
+
+func TestFileSystemDeleteEntry(t *testing.T) {
+
+	tempFolder, err := os.MkdirTemp(os.TempDir(), "teller-filesystem")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tempFolder)
+
+	f := &FileSystem{
+		logger:        GetTestLogger(),
+		rootDirectory: tempFolder,
+	}
+	err = createMockDirectoryStructure(f)
+	assert.NoError(t, err)
+
+	destFile := "settings/prod/billing-svc"
+	_, err = f.Get(core.KeyPath{Path: destFile, Decrypt: true})
+	assert.Nil(t, err)
+
+	err = f.Delete(core.KeyPath{Path: destFile, Decrypt: true})
+	assert.Nil(t, err)
+
+	_, err = f.Get(core.KeyPath{Path: destFile, Decrypt: true})
+	assert.NotNil(t, err)
+
+}

--- a/pkg/wizard_template.go
+++ b/pkg/wizard_template.go
@@ -246,4 +246,15 @@ providers:
         # source: Optional, Password is the default. Supported fields: Notes, Title, Password, URL, UserName
 
 {{end}}
+
+{{- if index .ProviderKeys "filesystem" }}
+
+  filesystem:
+    env_sync:
+      path: redis/config
+    env:
+      ETC_DSN:
+        path: redis/config/foobar
+
+{{end}}
 `


### PR DESCRIPTION
## Description
Create filesystem provider

## File Structure Example:
```
.
└── tmp/filesystem-provider
    ├── settings/
    │   ├── billing-svc
    │   └── all/
    │       ├── entry-a
    │       ├── entry-b
    │       └── entry-c
    |
    └── entry
```
## Example config:
```yaml
providers:

  filesystem:
    env_sync:
      path:  /tmp/filesystem-provider/settings
    env:
      ETC_DSN:
        path: /tmp/filesystem-provider/entry
      ETC_DSN2:
        path: /tmp/filesystem-provider/path/test/entry

```

## Put:
1. Update existing file
```sh
go run main.go put ETC_DSN=new-entry-value --providers filesystem
```
2. Creating recursively entry
In this example the path `/tmp/filesystem-provider/path/test/entry` not exists (see file structure example), the file `entry` will create under `path`, `test` folders (event if the folders not exists)
```sh
go run main.go put ETC_DSN2=new-entry-value --providers filesystem

```
3. with `--sync` will create a entry file under `/tmp/filesystem-provider/settings`
```sh
go run main.go put entry=1 --providers filesystem --sync
```

## Delete
1. delete entry.
```
go run main.go delete ETC_DSN1 --providers filesystem
```
2. didn't implement deleteMapping for now; I think it is too risky to delete a folder.



# Checklist
- [x] Tests
- [x] Documentation
- [x] Linting