### PR TITLE
Default value for opts

### DIFF
--- a/pkg/core/populate.go
+++ b/pkg/core/populate.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+const (
+	populateFromEnvironment = "env:"
+	populateWithDefault     = ":default:"
+)
+
 type Opts map[string]string
 type Populate struct {
 	opts map[string]string
@@ -21,9 +26,13 @@ func (p *Populate) FindAndReplace(path string) string {
 	populated := path
 	for k, v := range p.opts {
 		val := v
-		if strings.HasPrefix(v, "env:") {
-			evar := strings.TrimPrefix(v, "env:")
+		if strings.HasPrefix(v, populateFromEnvironment) {
+			evar := strings.TrimPrefix(v, populateFromEnvironment)
+			evar, defaultValue := p.parseDefaultValue(evar)
 			val = os.Getenv(evar)
+			if val == "" {
+				val = defaultValue
+			}
 		}
 		populated = strings.ReplaceAll(populated, fmt.Sprintf("{{%s}}", k), val)
 	}
@@ -35,11 +44,28 @@ func (p *Populate) KeyPath(kp KeyPath) KeyPath {
 	populated := path
 	for k, v := range p.opts {
 		val := v
-		if strings.HasPrefix(v, "env:") {
-			evar := strings.TrimPrefix(v, "env:")
+		if strings.HasPrefix(v, populateFromEnvironment) {
+			evar := strings.TrimPrefix(v, populateFromEnvironment)
+			evar, defaultValue := p.parseDefaultValue(evar)
 			val = os.Getenv(evar)
+			if val == "" {
+				val = defaultValue
+			}
 		}
 		populated = strings.ReplaceAll(populated, fmt.Sprintf("{{%s}}", k), val)
 	}
 	return kp.SwitchPath(path)
+}
+
+// parseDefaultValue returns that field name and the default value if `populateWithDefault` was found
+// Example 1: FOO:default:BAR -> the function return FOO, BAR
+// Example 2: FOO -> the function return FOO, "" (empty value)
+func (p *Populate) parseDefaultValue(evar string) (string, string) {
+	if strings.Contains(evar, populateWithDefault) {
+		data := strings.Split(evar, populateWithDefault)
+		if len(data) == 2 {
+			return data[0], data[1]
+		}
+	}
+	return evar, ""
 }

--- a/pkg/core/populate.go
+++ b/pkg/core/populate.go
@@ -60,10 +60,10 @@ func (p *Populate) KeyPath(kp KeyPath) KeyPath {
 // parseDefaultValue returns that field name and the default value if `populateWithDefault` was found
 // Example 1: FOO:default:BAR -> the function return FOO, BAR
 // Example 2: FOO -> the function return FOO, "" (empty value)
-func (p *Populate) parseDefaultValue(evar string) (string, string) {
+func (p *Populate) parseDefaultValue(evar string) (key, defaultValue string) {
 	if strings.Contains(evar, populateWithDefault) {
 		data := strings.Split(evar, populateWithDefault)
-		if len(data) == 2 {
+		if len(data) == 2 { //nolint
 			return data[0], data[1]
 		}
 	}

--- a/pkg/core/populate.go
+++ b/pkg/core/populate.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	populateFromEnvironment = "env:"
-	populateWithDefault     = ":default:"
+	populateWithDefault     = ","
 )
 
 type Opts map[string]string
@@ -58,13 +58,14 @@ func (p *Populate) KeyPath(kp KeyPath) KeyPath {
 }
 
 // parseDefaultValue returns that field name and the default value if `populateWithDefault` was found
-// Example 1: FOO:default:BAR -> the function return FOO, BAR
+// Example 1: FOO,BAR -> the function return FOO, BAR
 // Example 2: FOO -> the function return FOO, "" (empty value)
 func (p *Populate) parseDefaultValue(evar string) (key, defaultValue string) {
+
 	if strings.Contains(evar, populateWithDefault) {
-		data := strings.Split(evar, populateWithDefault)
-		if len(data) == 2 { //nolint
-			return data[0], data[1]
+		data := strings.SplitN(evar, populateWithDefault, 2) //nolint
+		if len(data) == 2 {                                  //nolint
+			return data[0], strings.TrimSpace(data[1])
 		}
 	}
 	return evar, ""

--- a/pkg/core/populate_test.go
+++ b/pkg/core/populate_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPopulatePath(t *testing.T) {
-	p := NewPopulate(map[string]string{"foo": "bar", "teller-env": "env:TELLER_TEST_FOO", "teller-env-default": "env:TELLER_TEST_DEFAULT:default:default-value"})
+	p := NewPopulate(map[string]string{"foo": "bar", "teller-env": "env:TELLER_TEST_FOO", "teller-env-default": "env:TELLER_TEST_DEFAULT,default-value"})
 
 	os.Setenv("TELLER_TEST_FOO", "test-foo")
 	assert.Equal(t, p.FindAndReplace("foo/{{foo}}/qux/{{foo}}"), "foo/bar/qux/bar")
@@ -64,8 +64,8 @@ func TestPopulateDefaultValue(t *testing.T) {
 	assert.Equal(t, key, "TELLER_TEST_FOO")
 	assert.Equal(t, value, "")
 
-	key, value = p.parseDefaultValue("TELLER_TEST_FOO:default:default-value")
+	key, value = p.parseDefaultValue("TELLER_TEST_FOO, default,,value")
 	assert.Equal(t, key, "TELLER_TEST_FOO")
-	assert.Equal(t, value, "default-value")
+	assert.Equal(t, value, "default,,value")
 
 }

--- a/pkg/core/populate_test.go
+++ b/pkg/core/populate_test.go
@@ -8,13 +8,14 @@ import (
 )
 
 func TestPopulatePath(t *testing.T) {
-	p := NewPopulate(map[string]string{"foo": "bar", "teller-env": "env:TELLER_TEST_FOO"})
+	p := NewPopulate(map[string]string{"foo": "bar", "teller-env": "env:TELLER_TEST_FOO", "teller-env-default": "env:TELLER_TEST_DEFAULT:default:default-value"})
 
 	os.Setenv("TELLER_TEST_FOO", "test-foo")
 	assert.Equal(t, p.FindAndReplace("foo/{{foo}}/qux/{{foo}}"), "foo/bar/qux/bar")
 	assert.Equal(t, p.FindAndReplace("foo/qux"), "foo/qux")
 	assert.Equal(t, p.FindAndReplace("foo/{{none}}"), "foo/{{none}}")
 	assert.Equal(t, p.FindAndReplace("foo/{{teller-env}}"), "foo/test-foo")
+	assert.Equal(t, p.FindAndReplace("foo/{{teller-env-default}}"), "foo/default-value")
 	assert.Equal(t, p.FindAndReplace(""), "")
 
 	kp := KeyPath{
@@ -41,4 +42,30 @@ func TestPopulatePath(t *testing.T) {
 		Decrypt:  true,
 		Optional: true,
 	})
+	kp = KeyPath{
+		Path:     "{{teller-env-default}}/hey",
+		Env:      "env",
+		Decrypt:  true,
+		Optional: true,
+	}
+	assert.Equal(t, p.KeyPath(kp), KeyPath{
+		Path:     "default-value/hey",
+		Env:      "env",
+		Decrypt:  true,
+		Optional: true,
+	})
+}
+
+func TestPopulateDefaultValue(t *testing.T) {
+
+	p := NewPopulate(map[string]string{})
+
+	key, value := p.parseDefaultValue("TELLER_TEST_FOO")
+	assert.Equal(t, key, "TELLER_TEST_FOO")
+	assert.Equal(t, value, "")
+
+	key, value = p.parseDefaultValue("TELLER_TEST_FOO:default:default-value")
+	assert.Equal(t, key, "TELLER_TEST_FOO")
+	assert.Equal(t, value, "default-value")
+
 }

--- a/pkg/wizard_template.go
+++ b/pkg/wizard_template.go
@@ -17,7 +17,7 @@ confirm: Are you sure you want to run on {{"{{stage}}"}}?
 # paths.
 #
 opts:
-  region: env:AWS_REGION    # you can get env variables with the 'env:' prefix
+  region: env:AWS_REGION    # you can get env variables with the 'env:' prefix, for default values if env not found use env:AWS_REGION:default:{DEFAULT_VALUE}
   stage: development
 
 

--- a/pkg/wizard_template.go
+++ b/pkg/wizard_template.go
@@ -17,7 +17,7 @@ confirm: Are you sure you want to run on {{"{{stage}}"}}?
 # paths.
 #
 opts:
-  region: env:AWS_REGION    # you can get env variables with the 'env:' prefix, for default values if env not found use env:AWS_REGION:default:{DEFAULT_VALUE}
+  region: env:AWS_REGION    # you can get env variables with the 'env:' prefix, for default values if env not found use comma. Example: env:AWS_REGION,{DEFAULT_VALUE}
   stage: development
 
 


### PR DESCRIPTION
## Related Issues
#29 

## Description
Adding the option to set default values for `ops` if the value not found from environment variable.

@jondot, this convention `:default:{XX}` is the best I can think. fell free to suggest another one.

# Checklist
- [x] Tests
- [x] Documentation
- [x] Linting