### PR TITLE
add scan command to e2e tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -24,6 +24,7 @@ The simple and fast way is based on `yml` file configuration. All you need to do
 | `init_snapshot.path`          | Create file in path.
 | `init_snapshot.file_name`     | File name.
 | `init_snapshot.content`       | File content.
+| `replace_stdout_content`      | Replace dynamic stdout content to static. for example, replace current timestemp to static text.
 | `expected_snapshot`           | Compare the init_snapshot folder with the expected snapshot content. If empty, this compare check will be ignored.
 | `expected_snapshot.path`      | Create file in path.
 | `expected_snapshot.file_name` | File name.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -97,7 +97,6 @@ func TestE2E(t *testing.T) {
 			}
 		})
 	}
-
 	// loop on register suites (from *.go files)
 	for name, suite := range register.GetSuites() {
 		t.Run(name, func(t *testing.T) {
@@ -105,7 +104,6 @@ func TestE2E(t *testing.T) {
 			// creates temp dir for test path.
 			tempFolder, err := os.MkdirTemp(t.TempDir(), strings.ReplaceAll(name, " ", ""))
 			assert.Nil(t, err, "could not create temp folder")
-
 			defer os.RemoveAll(tempFolder)
 
 			// initialized test case

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"testing"
@@ -61,10 +62,19 @@ func TestE2E(t *testing.T) {
 
 			flagsCommand := strings.TrimPrefix(snapshot.Command, removeBinaryPlaceholder)
 			stdout, stderr, err := testutils.ExecCmd(binaryPath, strings.Split(flagsCommand, " "), snapshotFolder)
-			assert.Nil(t, err, stderr)
+			if stdout == "" {
+				assert.Nil(t, err, stderr)
+			}
 
 			// In case the stdout/stderr include the dynamic folder path, we want to replace with static-content for better snapshot text compare
 			stdout, stderr = replaceFolderName(stdout, stderr, snapshotFolder)
+
+			if len(snapshot.ReplaceStdOutContent) > 0 {
+				for _, r := range snapshot.ReplaceStdOutContent {
+					var re = regexp.MustCompile(r.Search)
+					stdout = re.ReplaceAllString(stdout, r.Replace)
+				}
+			}
 
 			if snapshot.ExpectedStdOut != "" {
 				assert.Equal(t, snapshot.ExpectedStdOut, stdout)

--- a/e2e/tests/scan.yml
+++ b/e2e/tests/scan.yml
@@ -1,0 +1,52 @@
+---
+name: scan entries
+command: <binary-path> scan
+config_file_name: .teller.yml
+config_content: >
+  project: test
+
+  providers:
+    filesystem:
+      env_sync:
+        path: {{.Folder}}/settings/test/all
+      env:
+        FOO:
+          path: {{.Folder}}/settings/test/foo
+          severity: low
+        BAR:
+          path: {{.Folder}}/settings/test/bar
+          severity: medium
+init_snapshot:
+  - path: settings/test
+    file_name: foo
+    content: shazam
+  - path: settings/test
+    file_name: bar
+    content: shazam
+  - path: settings/test
+    file_name: file
+    content: content
+  - path: settings/test/all
+    file_name: secret-a
+    content: mailman
+  - path: settings/test/all
+    file_name: secret-b
+    content: shazam
+expected_snapshot:
+replace_stdout_content:
+  - search: "matches in [0-9].[0-9]+ms"
+    replace: matches in 1.000ms
+expected_stdout: |
+  [high] settings/test/all/secret-b (1,0): found match for filesystem/secret-b (sh*****)
+  [low] settings/test/all/secret-b (1,0): found match for filesystem/FOO (sh*****)
+  [medium] settings/test/all/secret-b (1,0): found match for filesystem/BAR (sh*****)
+  [high] settings/test/all/secret-a (1,0): found match for filesystem/secret-a (ma*****)
+  [high] settings/test/foo (1,0): found match for filesystem/secret-b (sh*****)
+  [low] settings/test/foo (1,0): found match for filesystem/FOO (sh*****)
+  [medium] settings/test/foo (1,0): found match for filesystem/BAR (sh*****)
+  [high] settings/test/bar (1,0): found match for filesystem/secret-b (sh*****)
+  [low] settings/test/bar (1,0): found match for filesystem/FOO (sh*****)
+  [medium] settings/test/bar (1,0): found match for filesystem/BAR (sh*****)
+
+  Scanning for 4 entries: found 10 matches in 1.000ms
+expected_stderr: 

--- a/e2e/tests/scan.yml
+++ b/e2e/tests/scan.yml
@@ -37,16 +37,16 @@ replace_stdout_content:
   - search: "matches in [0-9].[0-9]+(.*)"
     replace: matches in 1.000ms
 expected_stdout: |
+  [high] settings/test/all/secret-a (1,0): found match for filesystem/secret-a (ma*****)
   [high] settings/test/all/secret-b (1,0): found match for filesystem/secret-b (sh*****)
   [low] settings/test/all/secret-b (1,0): found match for filesystem/FOO (sh*****)
   [medium] settings/test/all/secret-b (1,0): found match for filesystem/BAR (sh*****)
-  [high] settings/test/all/secret-a (1,0): found match for filesystem/secret-a (ma*****)
-  [high] settings/test/foo (1,0): found match for filesystem/secret-b (sh*****)
-  [low] settings/test/foo (1,0): found match for filesystem/FOO (sh*****)
-  [medium] settings/test/foo (1,0): found match for filesystem/BAR (sh*****)
   [high] settings/test/bar (1,0): found match for filesystem/secret-b (sh*****)
   [low] settings/test/bar (1,0): found match for filesystem/FOO (sh*****)
   [medium] settings/test/bar (1,0): found match for filesystem/BAR (sh*****)
+  [high] settings/test/foo (1,0): found match for filesystem/secret-b (sh*****)
+  [low] settings/test/foo (1,0): found match for filesystem/FOO (sh*****)
+  [medium] settings/test/foo (1,0): found match for filesystem/BAR (sh*****)
 
   Scanning for 4 entries: found 10 matches in 1.000ms
 expected_stderr: 

--- a/e2e/tests/scan.yml
+++ b/e2e/tests/scan.yml
@@ -34,7 +34,7 @@ init_snapshot:
     content: shazam
 expected_snapshot:
 replace_stdout_content:
-  - search: "matches in [0-9].[0-9]+ms"
+  - search: "matches in [0-9].[0-9]+(.*)"
     replace: matches in 1.000ms
 expected_stdout: |
   [high] settings/test/all/secret-b (1,0): found match for filesystem/secret-b (sh*****)

--- a/e2e/testutils/config.go
+++ b/e2e/testutils/config.go
@@ -11,20 +11,26 @@ import (
 )
 
 type SnapshotSuite struct {
-	Name             string         `yaml:"name,omitempty"`
-	Command          string         `yaml:"command,omitempty"`
-	ConfigFileName   string         `yaml:"config_file_name,omitempty"`
-	Config           string         `yaml:"config_content,omitempty"`
-	InitSnapshot     []SnapshotData `yaml:"init_snapshot,omitempty"`
-	ExpectedSnapshot []SnapshotData `yaml:"expected_snapshot,omitempty"`
-	ExpectedStdOut   string         `yaml:"expected_stdout,omitempty"`
-	ExpectedStdErr   string         `yaml:"expected_stderr,omitempty"`
+	Name                 string                 `yaml:"name,omitempty"`
+	Command              string                 `yaml:"command,omitempty"`
+	ConfigFileName       string                 `yaml:"config_file_name,omitempty"`
+	Config               string                 `yaml:"config_content,omitempty"`
+	InitSnapshot         []SnapshotData         `yaml:"init_snapshot,omitempty"`
+	ExpectedSnapshot     []SnapshotData         `yaml:"expected_snapshot,omitempty"`
+	ExpectedStdOut       string                 `yaml:"expected_stdout,omitempty"`
+	ExpectedStdErr       string                 `yaml:"expected_stderr,omitempty"`
+	ReplaceStdOutContent []ReplaceStdOutContent `yaml:"replace_stdout_content,omitempty"`
 }
 
 type SnapshotData struct {
 	Path     string `yaml:"path"`
 	FileName string `yaml:"file_name"`
 	Content  string `yaml:"content"`
+}
+
+type ReplaceStdOutContent struct {
+	Search  string `yaml:"search"`
+	Replace string `yaml:"replace"`
 }
 
 // GetYmlSnapshotSuites returns list of snapshot suite from yml files

--- a/pkg/porcelain.go
+++ b/pkg/porcelain.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -129,8 +130,12 @@ func (p *Porcelain) PrintMatches(matches []core.Match) {
 	green := color.New(color.FgGreen).SprintFunc()
 	white := color.New(color.FgWhite).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
-	//nolint
-	for _, m := range matches {
+
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Path < matches[j].Path
+	})
+
+	for _, m := range matches { //nolint
 		sevcolor := white
 		if m.Entry.Severity == core.High {
 			sevcolor = red


### PR DESCRIPTION
## Description
Add `scan` e2e test. Scan test has a dynamic response by presenting the scan time. To compare the STDOUT I have added `replace_stdout_content` field to the e2e yaml configuration, which allows us to replace with regex dynamic content.

## Motivation and Context
coverage more Teller command

# Checklist
- [x] Tests
- [ ] Documentation
- [x] Linting